### PR TITLE
R_k indexing fix

### DIFF
--- a/examples/qpe.cpp
+++ b/examples/qpe.cpp
@@ -73,7 +73,7 @@ int main() {
             cmat Rj(2, 2);
             Rj << 1, 0, 0, std::exp(-1_i * pi / std::pow(2, j - m));
             result = applyCTRL(result, Rj, {m}, {j});
-            std::cout << "R" << j << "(" << m << ", " << j << ") ";
+            std::cout << "R" << j - m + 1 << "(" << m << ", " << j << ") ";
         }
         result = apply(result, gt.H, {j});
         std::cout << "H" << j << "\n";


### PR DESCRIPTION
Sorry about that, I did the in-line edit and accidentally changed the wrong part of the code. This one should be correct and the readout should look like the following:
`...`
`R2(0, 1) H1`
`R3(0, 2) R2(1, 2) H2`
`...`
Let me know if that works. 