### PR TITLE
Return post-measurement states as kets when relevant

### DIFF
--- a/include/classes/circuits/engines.hpp
+++ b/include/classes/circuits/engines.hpp
@@ -533,7 +533,7 @@ class QEngine : public IDisplay, public IJSON {
 
             idx mres = 0;
             std::vector<double> probs;
-            std::vector<cmat> states;
+            std::vector<ket> states;
 
             switch (measurements[m_ip].measurement_type_) {
                 case QCircuit::MeasureType::NONE:

--- a/include/instruments.hpp
+++ b/include/instruments.hpp
@@ -206,9 +206,9 @@ ip(const Eigen::MatrixBase<Derived>& phi, const Eigen::MatrixBase<Derived>& psi,
  * probabilities, and 3. Vector of post-measurement normalized states
  */
 template <typename Derived>
-std::tuple<idx, std::vector<double>, std::vector<cmat>>
+std::tuple<idx, std::vector<double>, std::vector<deduced_mat<Derived>>>
 measure(const Eigen::MatrixBase<Derived>& A, const std::vector<cmat>& Ks) {
-    const dyn_mat<typename Derived::Scalar>& rA = A.derived();
+    const deduced_mat<Derived>& rA = A.derived();
 
     // EXCEPTION CHECKS
 
@@ -229,7 +229,7 @@ measure(const Eigen::MatrixBase<Derived>& A, const std::vector<cmat>& Ks) {
     // probabilities
     std::vector<double> probs(Ks.size());
     // resulting states
-    std::vector<cmat> outstates(Ks.size());
+    std::vector<deduced_mat<Derived>> outstates(Ks.size());
 
     idx Dout = Ks[0].rows();
     //************ density matrix ************//
@@ -286,7 +286,7 @@ measure(const Eigen::MatrixBase<Derived>& A, const std::vector<cmat>& Ks) {
  * probabilities, and 3. Vector of post-measurement normalized states
  */
 template <typename Derived>
-std::tuple<idx, std::vector<double>, std::vector<cmat>>
+std::tuple<idx, std::vector<double>, std::vector<deduced_mat<Derived>>>
 measure(const Eigen::MatrixBase<Derived>& A,
         const std::initializer_list<cmat>& Ks) {
     return measure(A, std::vector<cmat>(Ks));
@@ -305,9 +305,9 @@ measure(const Eigen::MatrixBase<Derived>& A,
  * probabilities, and 3. Vector of post-measurement normalized states
  */
 template <typename Derived>
-std::tuple<idx, std::vector<double>, std::vector<cmat>>
+std::tuple<idx, std::vector<double>, std::vector<deduced_mat<Derived>>>
 measure(const Eigen::MatrixBase<Derived>& A, const cmat& U) {
-    const dyn_mat<typename Derived::Scalar>& rA = A.derived();
+    const deduced_mat<Derived>& rA = A.derived();
 
     // EXCEPTION CHECKS
 
@@ -350,7 +350,7 @@ measure(const Eigen::MatrixBase<Derived>& A, const cmat& U) {
  * probabilities, and 3. Vector of post-measurement normalized states
  */
 template <typename Derived>
-std::tuple<idx, std::vector<double>, std::vector<cmat>>
+std::tuple<idx, std::vector<double>, std::vector<deduced_mat<Derived>>>
 measure(const Eigen::MatrixBase<Derived>& A, const std::vector<cmat>& Ks,
         const std::vector<idx>& target, const std::vector<idx>& dims,
         bool destructive = true) {
@@ -403,7 +403,7 @@ measure(const Eigen::MatrixBase<Derived>& A, const std::vector<cmat>& Ks,
     // probabilities
     std::vector<double> probs(Ks.size());
     // resulting states
-    std::vector<cmat> outstates;
+    std::vector<deduced_mat<Derived>> outstates;
 
     if (destructive)
         outstates.resize(Ks.size(), cmat::Zero(Dsubsys_bar, Dsubsys_bar));
@@ -477,7 +477,7 @@ measure(const Eigen::MatrixBase<Derived>& A, const std::vector<cmat>& Ks,
  * probabilities, and 3. Vector of post-measurement normalized states
  */
 template <typename Derived>
-std::tuple<idx, std::vector<double>, std::vector<cmat>>
+std::tuple<idx, std::vector<double>, std::vector<deduced_mat<Derived>>>
 measure(const Eigen::MatrixBase<Derived>& A,
         const std::initializer_list<cmat>& Ks, const std::vector<idx>& target,
         const std::vector<idx>& dims, bool destructive = true) {
@@ -502,7 +502,7 @@ measure(const Eigen::MatrixBase<Derived>& A,
  * probabilities, and 3. Vector of post-measurement normalized states
  */
 template <typename Derived>
-std::tuple<idx, std::vector<double>, std::vector<cmat>>
+std::tuple<idx, std::vector<double>, std::vector<deduced_mat<Derived>>>
 measure(const Eigen::MatrixBase<Derived>& A, const std::vector<cmat>& Ks,
         const std::vector<idx>& target, idx d = 2, bool destructive = true) {
     const typename Eigen::MatrixBase<Derived>::EvalReturnType& rA = A.derived();
@@ -545,7 +545,7 @@ measure(const Eigen::MatrixBase<Derived>& A, const std::vector<cmat>& Ks,
  * probabilities, and 3. Vector of post-measurement normalized states
  */
 template <typename Derived>
-std::tuple<idx, std::vector<double>, std::vector<cmat>>
+std::tuple<idx, std::vector<double>, std::vector<deduced_mat<Derived>>>
 measure(const Eigen::MatrixBase<Derived>& A,
         const std::initializer_list<cmat>& Ks, const std::vector<idx>& target,
         idx d = 2, bool destructive = true) {
@@ -576,7 +576,7 @@ measure(const Eigen::MatrixBase<Derived>& A,
  * probabilities, and 3. Vector of post-measurement normalized states
  */
 template <typename Derived>
-std::tuple<idx, std::vector<double>, std::vector<cmat>>
+std::tuple<idx, std::vector<double>, std::vector<deduced_mat<Derived>>>
 measure(const Eigen::MatrixBase<Derived>& A, const cmat& V,
         const std::vector<idx>& target, const std::vector<idx>& dims,
         bool destructive = true) {
@@ -626,7 +626,7 @@ measure(const Eigen::MatrixBase<Derived>& A, const cmat& V,
     if (internal::check_cvector(rA)) {
         const ket& rpsi = A.derived();
         std::vector<double> probs(M);   // probabilities
-        std::vector<cmat> outstates(M); // resulting states
+        std::vector<deduced_mat<Derived>> outstates(M); // resulting states
 
 #ifdef HAS_OPENMP
 // NOLINTNEXTLINE
@@ -697,7 +697,7 @@ measure(const Eigen::MatrixBase<Derived>& A, const cmat& V,
  * probabilities, and 3. Vector of post-measurement normalized states
  */
 template <typename Derived>
-std::tuple<idx, std::vector<double>, std::vector<cmat>>
+std::tuple<idx, std::vector<double>, std::vector<deduced_mat<Derived>>>
 measure(const Eigen::MatrixBase<Derived>& A, const cmat& V,
         const std::vector<idx>& target, idx d = 2, bool destructive = true) {
     const typename Eigen::MatrixBase<Derived>::EvalReturnType& rA = A.derived();

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -105,6 +105,12 @@ template <typename Scalar> // Eigen::RowVectorX_type (where type = Scalar)
 using dyn_row_vect = Eigen::Matrix<Scalar, 1, Eigen::Dynamic>;
 
 /**
+ * \brief Matrix type deduced from Derived
+ */
+template < typename Derived >
+using deduced_mat = typename std::decay<decltype(std::declval<Derived>().eval())>::type;
+
+/**
  * \brief Quantumly-accessible Random Access Memory (qRAM)
  */
 using qram = std::vector<idx>;

--- a/unit_tests/tests/instruments.cpp
+++ b/unit_tests/tests/instruments.cpp
@@ -111,3 +111,14 @@ TEST(qpp_reset, Qudits) {}
 ///       idx d = 2)
 TEST(qpp_reset, Qubits) {}
 /******************************************************************************/
+
+TEST(qpp_measure, ket)
+{
+    using namespace qpp::literals;
+    auto const state = (0_ket + 1_ket).normalized().eval();
+    auto const res = qpp::measure(state, qpp::gt.Id2);
+    auto const& resulting_states = std::get<qpp::ST>(res);
+
+    EXPECT_EQ(resulting_states[0][0], 1.);
+    EXPECT_EQ(resulting_states[1][1], 1.);
+}


### PR DESCRIPTION
If I understand correctly, one can measure both kets and cmats, and the column dimension of the post-measurement states is always the same as the measured input ? Or at least the post-measurement states of measured kets are always kets.

If so, wouldn't it be more consistent and convenient to return kets when the input is a ket? For instance, one could use Eigen's vector method on a post-measurement state, such as element access:
```c++
auto const [result, probs, post_state] = measure(phi, gt.Id2);
auto const& el = post_state[0][1];
```
instead of:
```c++
auto const [result, probs, post_state] = measure(phi, gt.Id2);
auto const& el = post_state[0](1, 0);
```