### PR TITLE
Add missing matrix registration in QCircuit::measureV

### DIFF
--- a/include/classes/circuits/circuits.hpp
+++ b/include/classes/circuits/circuits.hpp
@@ -2955,14 +2955,17 @@ class QCircuit : public IDisplay, public IJSON {
         if (name.empty())
             name = "m" + qpp::Gates::get_instance().get_name(V);
 
+        std::size_t hashV = hash_eigen(V);
+        add_hash_(V, hashV);
+
         if (destructive) {
             measured_[target] = true;
             measurements_.emplace_back(MeasureType::MEASURE_V,
-                                       std::vector<std::size_t>{hash_eigen(V)},
+                                       std::vector<std::size_t>{hashV},
                                        std::vector<idx>{target}, c_reg, name);
         } else {
             measurements_.emplace_back(MeasureType::MEASURE_V_ND,
-                                       std::vector<std::size_t>{hash_eigen(V)},
+                                       std::vector<std::size_t>{hashV},
                                        std::vector<idx>{target}, c_reg, name);
         }
         step_types_.emplace_back(StepType::MEASUREMENT);
@@ -3024,15 +3027,18 @@ class QCircuit : public IDisplay, public IJSON {
         if (name.empty())
             name = "m" + qpp::Gates::get_instance().get_name(V);
 
+        std::size_t hashV = hash_eigen(V);
+        add_hash_(V, hashV);
+
         if (destructive) {
             for (auto&& elem : target)
                 measured_[elem] = true;
             measurements_.emplace_back(MeasureType::MEASURE_V_MANY,
-                                       std::vector<std::size_t>{hash_eigen(V)},
+                                       std::vector<std::size_t>{hashV},
                                        target, c_reg, name);
         } else {
             measurements_.emplace_back(MeasureType::MEASURE_V_MANY_ND,
-                                       std::vector<std::size_t>{hash_eigen(V)},
+                                       std::vector<std::size_t>{hashV},
                                        target, c_reg, name);
         }
         step_types_.emplace_back(StepType::MEASUREMENT);

--- a/include/classes/gates.hpp
+++ b/include/classes/gates.hpp
@@ -29,6 +29,8 @@
  * \brief Quantum gates
  */
 
+#include <array>
+
 #ifndef CLASSES_GATES_HPP_
 #define CLASSES_GATES_HPP_
 

--- a/include/classes/gates.hpp
+++ b/include/classes/gates.hpp
@@ -102,15 +102,7 @@ class Gates final : public internal::Singleton<const Gates> // const Singleton
      * \param n 3-dimensional real (unit) vector
      * \return Rotation gate
      */
-    cmat Rn(double theta, const std::vector<double>& n) const {
-        // EXCEPTION CHECKS
-
-        // check 3-dimensional vector
-        if (n.size() != 3)
-            throw exception::CustomException(
-                "qpp::Gates::Rn()", "n is not a 3-dimensional vector!");
-        // END EXCEPTION CHECKS
-
+    cmat Rn(double theta, const std::array<double, 3>& n) const {
         cmat result(2, 2);
         result = std::cos(theta / 2) * Id2 -
                  1_i * std::sin(theta / 2) * (n[0] * X + n[1] * Y + n[2] * Z);

--- a/unit_tests/tests/classes/circuits/circuits.cpp
+++ b/unit_tests/tests/classes/circuits/circuits.cpp
@@ -281,3 +281,13 @@ TEST(qpp_QCircuit_TFQ, SpecificQudits) {}
 ///       bool enclosed_in_curly_brackets = true) const override
 TEST(qpp_QCircuit_to_JSON, AllTests) {}
 /******************************************************************************/
+
+TEST(qpp_QCircuit, measureV)
+{
+    using namespace qpp;
+    auto circuit = QCircuit{ 1, 1 };
+    circuit.measureV(gt.Id2, 0, 0);
+
+    auto engine = QEngine{ circuit };
+    EXPECT_NO_THROW(engine.execute());
+}


### PR DESCRIPTION
After using ```QCircuit::measureV```, ```QEngine::execute``` crashes with exception ```"qpp::measure(): Object has zero size!"```.
This seems to be cause by the basis matrix not being registered in the hash table.

Also added a simplified Rotation method that uses ```std::array``` instead of ```std::vector```.