### PR TITLE
Better SVD algorithm and Full Schmidt function

### DIFF
--- a/include/functions.hpp
+++ b/include/functions.hpp
@@ -489,9 +489,7 @@ svd(const Eigen::MatrixBase<Derived>& A) {
         throw exception::ZeroSize("qpp::svd()");
     // END EXCEPTION CHECKS
 
-    Eigen::JacobiSVD<dyn_mat<typename Derived::Scalar>> sv(
-        rA, Eigen::DecompositionOptions::ComputeFullU |
-                Eigen::DecompositionOptions::ComputeFullV);
+    auto const sv = rA.bdcSvd(Eigen::ComputeFullU | Eigen::ComputeFullV);
 
     return std::make_tuple(sv.matrixU(), sv.singularValues(), sv.matrixV());
 }
@@ -514,9 +512,7 @@ dyn_col_vect<double> svals(const Eigen::MatrixBase<Derived>& A) {
         throw exception::ZeroSize("qpp::svals()");
     // END EXCEPTION CHECKS
 
-    Eigen::JacobiSVD<dyn_mat<typename Derived::Scalar>> sv(rA);
-
-    return sv.singularValues();
+    return rA.bdcSvd().singularValues();
 }
 
 /**
@@ -537,10 +533,7 @@ cmat svdU(const Eigen::MatrixBase<Derived>& A) {
         throw exception::ZeroSize("qpp::svdU()");
     // END EXCEPTION CHECKS
 
-    Eigen::JacobiSVD<dyn_mat<typename Derived::Scalar>> sv(
-        rA, Eigen::DecompositionOptions::ComputeFullU);
-
-    return sv.matrixU();
+    return rA.bdcSvd(Eigen::ComputeFullU).matrixU();
 }
 
 /**
@@ -561,10 +554,7 @@ cmat svdV(const Eigen::MatrixBase<Derived>& A) {
         throw exception::ZeroSize("qpp::svdV()");
     // END EXCEPTION CHECKS
 
-    Eigen::JacobiSVD<dyn_mat<typename Derived::Scalar>> sv(
-        rA, Eigen::DecompositionOptions::ComputeFullV);
-
-    return sv.matrixV();
+    return rA.bdcSvd(Eigen::ComputeFullV).matrixV();
 }
 
 // Matrix functional calculus

--- a/unit_tests/tests/entanglement.cpp
+++ b/unit_tests/tests/entanglement.cpp
@@ -572,3 +572,58 @@ TEST(qpp_schmidtprobs, Qubits) {
     EXPECT_NEAR(0, norm(result - expected), 1e-7);
 }
 /******************************************************************************/
+/// BEGIN template <typename Derived>
+///       std::tuple<cmat, cmat, dyn_col_vect<double>, dyn_col_vect<double>>
+////      schmidt(const Eigen::MatrixBase<Derived>& A, const std::vector<idx>& dims)
+TEST(qpp_schmidt, Qudits) {
+    // random 3 x 4 state
+    idx dA = 3, dB = 4, D = dA * dB, minD = std::min(dA, dB);
+    auto const psi = randket(D);
+
+    auto const t = schmidt(psi, {dA, dB});
+    auto const& basisA = std::get<0>(t);
+    auto const& basisB = std::get<1>(t);
+    auto const& coeffs = std::get<2>(t);
+    auto const& probs  = std::get<3>(t);
+
+    auto const basisA_ref = schmidtA(psi, {dA, dB});
+    EXPECT_NEAR(0, norm(basisA - basisA_ref), 1e-7);
+
+    auto const basisB_ref = schmidtB(psi, {dA, dB});
+    EXPECT_NEAR(0, norm(basisB - basisB_ref), 1e-7);
+
+    auto const coeffs_ref = schmidtcoeffs(psi, {dA, dB});
+    EXPECT_NEAR(0, norm(coeffs - coeffs_ref), 1e-7);
+
+    auto const probs_ref_vect = schmidtprobs(psi, {dA, dB});
+    auto const probs_ref = dyn_col_vect<double>::Map(probs_ref_vect.data(), probs_ref_vect.size());
+    EXPECT_NEAR(0, norm(probs - probs_ref), 1e-7);
+}
+/******************************************************************************/
+/// BEGIN template <typename Derived>
+///       std::tuple<cmat, cmat, dyn_col_vect<double>, dyn_col_vect<double>>
+////      schmidt(const Eigen::MatrixBase<Derived>& A, idx d = 2)
+TEST(qpp_schmidt, Qubits) {
+    // random 5 x 5 state
+    idx d = 5, D = d * d;
+    auto const psi = randket(D);
+
+    auto const t = schmidt(psi, d);
+    auto const& basisA = std::get<0>(t);
+    auto const& basisB = std::get<1>(t);
+    auto const& coeffs = std::get<2>(t);
+    auto const& probs  = std::get<3>(t);
+
+    auto const basisA_ref = schmidtA(psi, d);
+    EXPECT_NEAR(0, norm(basisA - basisA_ref), 1e-7);
+
+    auto const basisB_ref = schmidtB(psi, d);
+    EXPECT_NEAR(0, norm(basisB - basisB_ref), 1e-7);
+
+    auto const coeffs_ref = schmidtcoeffs(psi, d);
+    EXPECT_NEAR(0, norm(coeffs - coeffs_ref), 1e-7);
+
+    auto const probs_ref_vect = schmidtprobs(psi, d);
+    auto const probs_ref = dyn_col_vect<double>::Map(probs_ref_vect.data(), probs_ref_vect.size());
+    EXPECT_NEAR(0, norm(probs - probs_ref), 1e-7);
+}


### PR DESCRIPTION
I replaced ```Eigen::JacobiSVD``` with ```Eigen::BDCSVD``` for better performances. See Eigen' s doc : https://eigen.tuxfamily.org/dox/group__TutorialLinearAlgebra.html
> The most general and accurate method to solve under- or over-determined linear systems in the least squares sense, is the SVD decomposition. Eigen provides two implementations. The recommended one is the BDCSVD class, which scales well for large problems and automatically falls back to the JacobiSVD class for smaller problems.

The fallback to `JacobiSVD` happens for matrices smaller than 16x16, but it's customizable.
Here are some measurements, where `A` is 7 qubits and `B` is 5 qubits:
With ```Eigen::JacobiSVD```:
```
schmidtA:   5374 us
schmidtcoeffs:   1720 us
schmidtB:   1910 us
Total: 9005 us
```
With ```Eigen::BDCSVD```:
```
schmidtA:   1993 us
schmidtcoeffs:   965 us
schmidtB:   1019 us
Total: 3979 us
```
Note that matrices `U` and `V` will be different between both algorithms (as they are not unique).

Also, computing everything separately is expensive, so I added a full ```schmidt()``` function that computes everything in one go.
It should take around `2000 us`, but I didn't measured it directly; I measured ```Eigen::BDCSVD::compute(Eigen::ComputeFullU | Eigen::ComputeFullV)``` in my examples.