### PR TITLE
bugfix in qpp::QEngine::reset()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Pre-release
+    - Minor bugfix in pyqpp setup.py that prevented pip install from remote
+    - Bug fix in qpp::QEngine::execute() that prevented setting the initial
+      state of the engine to a custom state
+
 Version 4.3.2 - 12 June 2023
     - This is a maintenance release
     - Compiling errors fixed on SunOS/OpenIndiana


### PR DESCRIPTION
prevented setting the initial state of the engine to a custom state