### PR TITLE
Fix throw in QEngineT::reset when the circuit has a measure.

### DIFF
--- a/include/qpp/classes/qengine.hpp
+++ b/include/qpp/classes/qengine.hpp
@@ -1225,7 +1225,7 @@ class QEngineT : public QBaseEngine<T, QCircuit> {
      * measurement statistics hash table
      */
     virtual QEngineT& reset(bool reset_stats = true) {
-        qeng_st_.reset(qeng_st_.qstate_);
+        qeng_st_.reset();
 
         if (reset_stats) {
             this->reset_stats();

--- a/unit_tests/tests/classes/qengine.cpp
+++ b/unit_tests/tests/classes/qengine.cpp
@@ -54,7 +54,15 @@ TEST(qpp_QEngineT_get_stats, AllTests) {}
 TEST(qpp_QEngineT_post_select_ok, AllTests) {}
 
 /// BEGIN QEngineT& QEngineT::reset(bool reset_stats = true)
-TEST(qpp_QEngineT_reset, AllTests) {}
+TEST(qpp_QEngineT_reset, AllTests) {
+  auto circuit = qpp::QCircuit{ 2, 1 };
+  circuit.measure(0, 0);
+  auto engine = qpp::QEngine{ circuit };
+
+  auto const psi = qpp::randket(4).eval();
+  engine.reset().set_state(psi).execute();
+  EXPECT_NO_THROW(engine.reset().set_state(psi).execute());
+}
 
 /// BEGIN QEngineT& QEngineT::reset_stats()
 TEST(qpp_QEngineT_reset_stats, AllTests) {}


### PR DESCRIPTION
Hi,

It threw a DimsNotEqual exception because a destructive measurement would change the dimension of the state during execution. Resetting the initial state with the final state caused the exception.

- [ ] TODO: correct the documentation of `QEngineT::reset`

Another solution would be to simplify `QEngineT::reset` to match its documentation and always reset the state to zero.