### PR TITLE
Support Eigen3 5.0.0

### DIFF
--- a/cmake/qpp_eigen3.cmake
+++ b/cmake/qpp_eigen3.cmake
@@ -1,5 +1,5 @@
 message(STATUS "Detecting Eigen3...")
-find_package(Eigen3 3.0 QUIET NO_MODULE)
+find_package(Eigen3 QUIET NO_MODULE)
 if(NOT TARGET Eigen3::Eigen)
   # Install Eigen3 on demand
   include(FetchContent)


### PR DESCRIPTION
Closes #191

There doesn't seem to be a specific version requirement here.

If a max version is needed, can do 2 attempts (range version only works on 3.4.1+)
```cmake
find_package(Eigen3 3...5 QUIET NO_MODULE)
if(NOT TARGET Eigen3::Eigen)
  find_package(Eigen3 3.0 QUIET NO_MODULE)
endif()
```
